### PR TITLE
Resolve Issue #6

### DIFF
--- a/app/controllers/api/v1/shifts_controller.rb
+++ b/app/controllers/api/v1/shifts_controller.rb
@@ -66,6 +66,16 @@ class Api::V1::ShiftsController < ApiController
   def update
     validate_params
     if shift = Shift.find(params[:id])
+      if params[:user_ids]
+        shift.users = [];
+        params[:user_ids].each do |id|
+          puts 'id'
+          puts id.is_a? Integer
+          @user = User.find(id)
+          puts @user.shifts.ids
+          shift.users << @user
+        end
+      end
       shift.update(@prime_params)
       data = {
         shift: format_shifts([shift]),

--- a/app/controllers/api/v1/shifts_controller.rb
+++ b/app/controllers/api/v1/shifts_controller.rb
@@ -69,8 +69,6 @@ class Api::V1::ShiftsController < ApiController
       if params[:user_ids]
         shift.users = [];
         params[:user_ids].each do |id|
-          puts 'id'
-          puts id.is_a? Integer
           @user = User.find(id)
           puts @user.shifts.ids
           shift.users << @user

--- a/app/javascript/src/actions/shifts.js
+++ b/app/javascript/src/actions/shifts.js
@@ -66,10 +66,24 @@ const addUserToShift = (userID, shiftID) => (
   })
 );
 
+const dragDropUpdate = (oldShifts, newShift) => {
+  // NOTE: There is both a oldShift and oldShifts variable and the same for newShift and newShifts
+  const oldShift = oldShifts.find(shift => shift.id == newShift.id);
+  const index = oldShifts.indexOf(oldShift);
+  console.log('index', index);
+  const newShifts = [...oldShifts];
+  newShifts.splice(index, 1, newShift);
+  return {
+    type: 'DRAG_DROP',
+    payload: newShifts,
+  };
+};
+
 export {
   getAllShifts,
   updateShift,
   createShift,
   deleteShift,
   addUserToShift,
+  dragDropUpdate,
 };

--- a/app/javascript/src/actions/shifts.js
+++ b/app/javascript/src/actions/shifts.js
@@ -70,7 +70,6 @@ const dragDropUpdate = (oldShifts, newShift) => {
   // NOTE: There is both a oldShift and oldShifts variable and the same for newShift and newShifts
   const oldShift = oldShifts.find(shift => shift.id == newShift.id);
   const index = oldShifts.indexOf(oldShift);
-  console.log('index', index);
   const newShifts = [...oldShifts];
   newShifts.splice(index, 1, newShift);
   return {

--- a/app/javascript/src/actions/shifts.js
+++ b/app/javascript/src/actions/shifts.js
@@ -41,12 +41,12 @@ const createShift = data => (
 const deleteShift = id => (
   crud({
     dispatch: {
-      begin: 'BEGIN_GET_SHIFTS',
-      end: 'END_GET_SHIFTS',
-      fail: 'FAILED_GET_SHIFTS',
+      begin: 'BEGIN_DELETE_SHIFT',
+      end: 'END_DELETE_SHIFT',
+      fail: 'FAILED_DELETE_SHIFT',
     },
     method: 'DELETE',
-    url: `/api/v1/shifts${id}`,
+    url: `/api/v1/shifts/${id}`,
   })
 );
 
@@ -71,4 +71,5 @@ export {
   updateShift,
   createShift,
   deleteShift,
+  addUserToShift,
 };

--- a/app/javascript/src/app.jsx
+++ b/app/javascript/src/app.jsx
@@ -20,7 +20,8 @@ import App from './containers/App'
 
 // CSS/styling
 import 'semantic-ui-css/semantic.min.css';
-import "react-big-calendar/lib/css/react-big-calendar.css";
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+import 'react-big-calendar/lib/addons/dragAndDrop/styles.css';
 
 import { configureStore, DevTools, history } from './utils/store';
 

--- a/app/javascript/src/components/calendar/ShiftUpdateModal.jsx
+++ b/app/javascript/src/components/calendar/ShiftUpdateModal.jsx
@@ -7,16 +7,28 @@ import { Button, Form, Modal } from 'semantic-ui-react';
 import UpdateShiftForm from './update/UpdateShiftForm';
 
 class ShiftUpdateModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { open: false };
+    this.close = this.close.bind(this);
+  }
+
+  open = () => this.setState({ open: true });
+  close = () => this.setState({ open: false });
 
   render() {
+    const { open } = this.state;
     return (
       <Modal
+        open={open}
+        onOpen={this.open}
+        onClose={this.close}
         closeIcon
         trigger={<Button>Update</Button>}
       >
         <Modal.Header>Update shift</Modal.Header>
         <Modal.Content>
-          <UpdateShiftForm {...this.props} />
+          <UpdateShiftForm {...this.props} close={this.close} />
         </Modal.Content>
       </Modal>
     );

--- a/app/javascript/src/components/calendar/ShiftUpdateModal.jsx
+++ b/app/javascript/src/components/calendar/ShiftUpdateModal.jsx
@@ -16,6 +16,11 @@ class ShiftUpdateModal extends Component {
   open = () => this.setState({ open: true });
   close = () => this.setState({ open: false });
 
+  updateClose = () => {
+    this.props.closeShiftView();
+    this.close();
+  };
+
   render() {
     const { open } = this.state;
     return (
@@ -28,7 +33,7 @@ class ShiftUpdateModal extends Component {
       >
         <Modal.Header>Update shift</Modal.Header>
         <Modal.Content>
-          <UpdateShiftForm {...this.props} close={this.close} />
+          <UpdateShiftForm {...this.props} close={this.updateClose} />
         </Modal.Content>
       </Modal>
     );

--- a/app/javascript/src/components/calendar/ShiftUpdateModal.jsx
+++ b/app/javascript/src/components/calendar/ShiftUpdateModal.jsx
@@ -24,7 +24,7 @@ class ShiftUpdateModal extends Component {
         onOpen={this.open}
         onClose={this.close}
         closeIcon
-        trigger={<Button>Update</Button>}
+        trigger={<Button positive>Update</Button>}
       >
         <Modal.Header>Update shift</Modal.Header>
         <Modal.Content>

--- a/app/javascript/src/components/calendar/ShiftViewModal.jsx
+++ b/app/javascript/src/components/calendar/ShiftViewModal.jsx
@@ -10,6 +10,7 @@ class ShiftViewModal extends Component {
 
   render() {
     const { shiftData } = this.props;
+    console.log(shiftData);
     return (
         <React.Fragment>
           <Modal.Header>
@@ -23,6 +24,14 @@ class ShiftViewModal extends Component {
             </Modal.Description>
             <Modal.Description>
               {shiftData.note}
+            </Modal.Description>
+            <Modal.Description as="h4">
+              Users:
+            </Modal.Description>
+            <Modal.Description>
+              {shiftData.users.map(user => (
+                <div key={user.name}>{user.name}</div>
+              ))}
             </Modal.Description>
           </Modal.Content>
         </React.Fragment>

--- a/app/javascript/src/components/calendar/ShiftViewModal.jsx
+++ b/app/javascript/src/components/calendar/ShiftViewModal.jsx
@@ -10,7 +10,6 @@ class ShiftViewModal extends Component {
 
   render() {
     const { shiftData } = this.props;
-    console.log(shiftData);
     return (
         <React.Fragment>
           <Modal.Header>

--- a/app/javascript/src/components/calendar/index.jsx
+++ b/app/javascript/src/components/calendar/index.jsx
@@ -138,6 +138,7 @@ class BigCal extends Component {
         {/* Shift Create Modal */}
         <Modal
           closeIcon
+          closeOnDimmerClick={false}
           open={openShiftCreate}
           onClose={() => this.onClose('create')}
         >

--- a/app/javascript/src/components/calendar/index.jsx
+++ b/app/javascript/src/components/calendar/index.jsx
@@ -146,6 +146,7 @@ class BigCal extends Component {
             <ShiftUpdateModal
               {...this.props}
               shiftData={shiftData} updateShiftData={this.updateShiftData}
+              closeShiftView={() => this.onClose('view')}
             />
           </Modal.Actions>
         </Modal>

--- a/app/javascript/src/components/calendar/index.jsx
+++ b/app/javascript/src/components/calendar/index.jsx
@@ -109,9 +109,6 @@ class BigCal extends Component {
               {...this.props}
               shiftData={shiftData} updateShiftData={this.updateShiftData}
             />
-            <Button onClick={() => this.onClose('view')}>
-              Close
-            </Button>
           </Modal.Actions>
         </Modal>
         {/* Shift Create Modal */}

--- a/app/javascript/src/components/calendar/index.jsx
+++ b/app/javascript/src/components/calendar/index.jsx
@@ -1,6 +1,7 @@
-import React, { Component } from "react";
-import Calendar from "react-big-calendar";
-import moment from "moment";
+import React, { Component } from 'react';
+import Calendar from 'react-big-calendar';
+import withDragAndDrop from 'react-big-calendar/lib/addons/dragAndDrop';
+import moment from 'moment';
 
 // semantic-ui
 import { Button, Modal } from 'semantic-ui-react';
@@ -11,6 +12,8 @@ import ShiftCreateModal from './ShiftCreateModal';
 import ShiftUpdateModal from './ShiftUpdateModal';
 
 const localizer = Calendar.momentLocalizer(moment);
+
+const DragDropCal = withDragAndDrop(Calendar);
 
 class BigCal extends Component {
   constructor (props) {
@@ -32,6 +35,24 @@ class BigCal extends Component {
       openShiftView: true,
       shiftData,
     });
+  };
+
+  resizeEvent = ({ event, start, end }) => {
+    const data = {
+      ...event,
+      start_time: start,
+      end_time: end,
+    };
+    this.props.updateShift(event.id, data);
+  };
+
+  moveEvent = ({ event, start, end }) => {
+    const data = {
+      ...event,
+      start_time: start,
+      end_time: end,
+    };
+    this.props.updateShift(event.id, data);
   };
 
   onClose = (type) => {
@@ -83,7 +104,10 @@ class BigCal extends Component {
 
     return (
       <div>
-        <Calendar
+        <DragDropCal
+          resizeable
+          onEventDrop={this.moveEvent}
+          onEventResize={this.resizeEvent}
           step={30}
           timeslots={4}
           selectable

--- a/app/javascript/src/components/calendar/index.jsx
+++ b/app/javascript/src/components/calendar/index.jsx
@@ -60,6 +60,13 @@ class BigCal extends Component {
     this.setState({ shiftData });
   };
 
+  handleDelete = () => {
+    const { shiftData } = this.state;
+    const { deleteShift } = this.props;
+    deleteShift(shiftData.id);
+    this.onClose('view');
+  };
+
   render() {
     const {
       start, end,
@@ -97,6 +104,7 @@ class BigCal extends Component {
         >
           <ShiftViewModal shiftData={shiftData}/>
           <Modal.Actions>
+            <Button negative onClick={this.handleDelete}>Delete</Button>
             <ShiftUpdateModal
               {...this.props}
               shiftData={shiftData} updateShiftData={this.updateShiftData}

--- a/app/javascript/src/components/calendar/index.jsx
+++ b/app/javascript/src/components/calendar/index.jsx
@@ -38,20 +38,34 @@ class BigCal extends Component {
   };
 
   resizeEvent = ({ event, start, end }) => {
+    const shifts = this.props.shifts.team_shifts;
     const data = {
       ...event,
-      start_time: start,
+      start, end, // replaces old start and end elements for redux and frontend
+      start_time: start, // API uses start_time & end_time
       end_time: end,
     };
+
+    // updates shift data locally to remove lag and dependence of API
+    this.props.dragDropUpdate(shifts, data);
+
+    // updates on DB with API
     this.props.updateShift(event.id, data);
   };
 
   moveEvent = ({ event, start, end }) => {
+    const shifts = this.props.shifts.team_shifts;
     const data = {
       ...event,
-      start_time: start,
+      start, end, // replaces old start and end elements for redux and frontend
+      start_time: start, // API uses start_time & end_time
       end_time: end,
     };
+
+    // updates shift data locally to remove lag and dependence of API
+    this.props.dragDropUpdate(shifts, data);
+
+    // updates on DB with API
     this.props.updateShift(event.id, data);
   };
 

--- a/app/javascript/src/components/calendar/update/UpdateShiftForm.jsx
+++ b/app/javascript/src/components/calendar/update/UpdateShiftForm.jsx
@@ -5,8 +5,11 @@ import { Form } from 'semantic-ui-react';
 
 class UpdateShiftForm extends Component {
 
+  state = { error: false };
+
   onInputChange = (e, { value, id }) => {
     const { updateShiftData, shiftData } = this.props;
+    this.setState({ errors: [] });
     updateShiftData({
       ...shiftData,
       [id]: value,
@@ -15,6 +18,8 @@ class UpdateShiftForm extends Component {
 
   handleUpdate = () => {
     const { close, shiftData, updateShift } = this.props;
+    if (this.checkErrors(shiftData)) return;
+
     const data = {
       ...shiftData,
       start_time: shiftData.start,
@@ -22,6 +27,16 @@ class UpdateShiftForm extends Component {
     };
     updateShift(shiftData.id, data);
     close();
+  };
+
+  checkErrors = data => {
+    if (data.title.length == 0) {
+      this.setState({ error: true });
+      return true;
+    } else {
+      this.setState({ error: false });
+      return false;
+    }
   };
 
   render() {
@@ -47,7 +62,7 @@ class UpdateShiftForm extends Component {
           placeholder="Enter a title here"
           value={title}
           onChange={this.onInputChange}
-          // error={error}
+          error={this.state.error}
         />
         <Form.TextArea
           id="note"
@@ -63,7 +78,7 @@ class UpdateShiftForm extends Component {
           options={userOptions}
           defaultValue={user_ids}
           onChange={this.onInputChange}
-          // placeholder="(Default: You)"
+          placeholder="(Default: You)"
         />
         <Form.Button
           onClick={this.handleUpdate}

--- a/app/javascript/src/components/calendar/update/UpdateShiftForm.jsx
+++ b/app/javascript/src/components/calendar/update/UpdateShiftForm.jsx
@@ -14,7 +14,14 @@ class UpdateShiftForm extends Component {
   };
 
   handleUpdate = () => {
-    console.log(this.props.shiftData);
+    const { close, shiftData, updateShift } = this.props;
+    const data = {
+      ...shiftData,
+      start_time: shiftData.start,
+      end_time: shiftData.end,
+    };
+    updateShift(shiftData.id, data);
+    close();
   };
 
   render() {

--- a/app/javascript/src/containers/Calendar.jsx
+++ b/app/javascript/src/containers/Calendar.jsx
@@ -16,7 +16,9 @@ import {
   getAllShifts,
   updateShift,
   createShift,
-  deleteShift,  } from '../actions/shifts';
+  deleteShift,
+  dragDropUpdate,
+} from '../actions/shifts';
 import { getTeam } from '../actions/team';
 
 class Calendar extends Component {
@@ -28,13 +30,6 @@ class Calendar extends Component {
   }
 
   render () {
-    const {
-      shifts,
-      getAllShifts,
-      updateShift,
-      createShift,
-      deleteShift,
-    } = this.props;
     return (
       <div>
         <NavBar />
@@ -70,6 +65,7 @@ const mapDispatchToProps = (dispatch) => {
       updateShift,
       createShift,
       deleteShift,
+      dragDropUpdate,
       getTeam,
     },
     dispatch);

--- a/app/javascript/src/reducers/shifts.js
+++ b/app/javascript/src/reducers/shifts.js
@@ -63,9 +63,9 @@ const shifts = (state=initialState, action) => {
     case 'END_PUT_SHIFT': {
       return {
         ...endState,
-        // team_shifts: action.payload.data.data.team_shifts,
-        // user_shifts: action.payload.data.data.user_shifts,
-        // shift: action.payload.data.data.shift,
+        team_shifts: action.payload.data.data.team_shifts,
+        user_shifts: action.payload.data.data.user_shifts,
+        shift: action.payload.data.data.shift,
         responseObject: action.payload,
       };
     }

--- a/app/javascript/src/reducers/shifts.js
+++ b/app/javascript/src/reducers/shifts.js
@@ -95,6 +95,30 @@ const shifts = (state=initialState, action) => {
       };
     }
 
+    case 'BEGIN_DELETE_SHIFT': {
+      return {
+        ...state,
+        isLoading: true,
+      };
+    }
+
+    case 'FAILED_DELETE_SHIFT': {
+      return {
+        ...failedState,
+        errorMessage: action.payload.message,
+        errorObject: action.payload,
+      };
+    }
+
+    case 'END_DELETE_SHIFT': {
+      return {
+        ...endState,
+        team_shifts: action.payload.data.data.team_shifts,
+        user_shifts: action.payload.data.data.user_shifts,
+        responseObject: action.payload,
+      };
+    }
+
     case 'END_LOGOUT': {
       return initialState;
     }

--- a/app/javascript/src/reducers/shifts.js
+++ b/app/javascript/src/reducers/shifts.js
@@ -119,6 +119,13 @@ const shifts = (state=initialState, action) => {
       };
     }
 
+    case 'DRAG_DROP': {
+      return {
+        ...state,
+        team_shifts: action.payload,
+      };
+    }
+
     case 'END_LOGOUT': {
       return initialState;
     }


### PR DESCRIPTION
Closes #6

#### Changes
1. Updating Shifts
   a. Clicking on any Shift, then clicking "Update", and update shift information is a live and functional feature.
    b. Update Shift time by dragging or dropping the event block on the Calendar.
2. Delete Shifts
    a. User can delete shifts by clicking the "Delete" button in the Shift View modal.
3. Fixed bug (a issue page was not mad, but it was discussed in PR #3) that would not allow the Create Shift Modal to open properly in some cases.  