### PR TITLE
Add user's shifts to dashboard

### DIFF
--- a/app/javascript/src/components/dashboard/MyShifts.jsx
+++ b/app/javascript/src/components/dashboard/MyShifts.jsx
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import moment from 'moment';
+
+import { Card, Header } from 'semantic-ui-react';
+
+class MyShifts extends Component {
+
+    constructor(props) {
+        super(props);
+    }
+
+    filterShifts = (shift) => {
+        // NOTE(anesu): We only want shifts from the next 7 days
+        const daysToAdd = 7;
+
+        const shiftStartTime = new Date(shift.start);
+        const now = new Date();
+        const sevenDaysFromNow = new Date();
+        sevenDaysFromNow.setDate(now.getDate() + daysToAdd); 
+
+
+        return shiftStartTime > now && shiftStartTime < sevenDaysFromNow;
+    }
+
+    sortByEarliestShiftsFirst = (shift1, shift2)  => {
+        return new Date(shift1.start) > new Date(shift2.start);
+    }
+
+    mapShiftToCard = (shift) => {
+        const start = moment(new Date(shift.start))
+            .calendar();
+        const end = moment(new Date(shift.end))
+            .format("h:mmA");
+        const timeTillShift = moment(new Date(shift.start))
+            .startOf(shift.start)
+            .fromNow();
+
+        return {
+            header: shift.title,
+            description: `${start} until ${end}`,
+            meta: shift.note,
+            extra: timeTillShift,
+        }
+    }
+
+    render() {
+        const items = this.props.user_shifts
+            .filter(this.filterShifts)
+            .sort(this.sortByEarliestShiftsFirst)
+            .map(this.mapShiftToCard);
+
+        return (
+           <div>
+               <Header>Upcoming Shifts</Header>
+                <Card.Group items={items} />
+           </div>       
+        );
+    }
+
+}
+
+export default MyShifts;

--- a/app/javascript/src/components/dashboard/MyShifts.jsx
+++ b/app/javascript/src/components/dashboard/MyShifts.jsx
@@ -50,10 +50,12 @@ class MyShifts extends Component {
             .map(this.mapShiftToCard);
 
         return (
-           <div>
-               <Header>Upcoming Shifts</Header>
-                <Card.Group items={items} />
-           </div>       
+            <Card fluid raised style={{marginTop: "16px"}}>
+                    <Card.Content>
+                        <Card.Header>Upcoming Shifts</Card.Header>
+                    </Card.Content>
+                <Card.Group items={items} style={{ margin: "8px", marginTop: "0px" }} />
+           </Card>      
         );
     }
 

--- a/app/javascript/src/containers/Dashboard.jsx
+++ b/app/javascript/src/containers/Dashboard.jsx
@@ -7,6 +7,7 @@ import { bindActionCreators } from 'redux';
 // components
 import Test from './../components/Test';
 import NavBar from './NavBar';
+import MyShifts from './../components/dashboard/MyShifts';
 
 class Dashboard extends Component {
   render () {
@@ -14,7 +15,7 @@ class Dashboard extends Component {
       <div>
         <NavBar />
         <div className="body">
-          Dashboard
+          <MyShifts {...this.props.shifts}/>
         </div>
       </div>
     );
@@ -27,6 +28,7 @@ const mapStateToProps = state => {
   return {
     user: state.user,
     login: state.login,
+    shifts: state.shifts,
   };
 };
 


### PR DESCRIPTION
Why:
Make it easier to view my upcoming shifts

This change addresses the need by:
Added cards to represent each shift

Test plan:
- Login to GTHC
- Navigate to calendar
- Create a shift
- Navigate to dashboard
- See shift