### PR TITLE
Add exception handling to notification cancellation

### DIFF
--- a/app/admin/posts.rb
+++ b/app/admin/posts.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Post do
     def create
       # Good
       @post = Post.new(permitted_params[:post])
-      #puts "Making new post notification title: #{@post.title}, body: #{@post.body}"
+      puts "Making new post notification title: #{@post.title}, body: #{@post.body}"
       helpers.post_notification(title=@post.title, content=@post.body)
       if @post.save
         redirect_to '/admin/posts'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
     greeting = ['Hey!', 'Just a heads up!', 'Hi!', 'Hey there!'].sample
     if content.nil? and !time.nil?
       start_time_str = shift.start_time.in_time_zone("EST").strftime("%I:%M %p")
-    content = "#{greeting} Your #{start_time_str} tent shift in K-Ville starts in #{min_before} minutes!"
+      content = "#{greeting} Your #{start_time_str} tent shift in K-Ville starts in #{min_before} minutes!"
     elsif content.nil?
       content = "#{greeting} Your tent shift in K-Ville starts in #{min_before} minutes!"
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,9 +12,14 @@ module ApplicationHelper
     # Notification time is min_before minutes before shift, if not sending now
     time = send_now ? nil : shift.start_time - min_before*60
     title = "Upcoming Shift Reminder" if title.nil?
-    if content.nil?
-      content = "Hey! Your tent shift in K-Ville starts in #{min_before} minutes!"
+    greeting = ['Hey!', 'Just a heads up!', 'Hi!', 'Hey there!'].sample
+    if content.nil? and !time.nil?
+      start_time_str = shift.start_time.in_time_zone("EST").strftime("%I:%M %p")
+    content = "#{greeting} Your #{start_time_str} tent shift in K-Ville starts in #{min_before} minutes!"
+    elsif content.nil?
+      content = "#{greeting} Your tent shift in K-Ville starts in #{min_before} minutes!"
     end
+    puts "Scheduling shift notification with time: #{time} title: #{title} content: #{content} netIDs: #{netids.join(', ')}"
     onesignal_id = create_notification(netids, recipient_type='netids', title, content, time, test)
     # Store notification record in db for each user
     userids = shift.users.collect(&:id)
@@ -69,7 +74,7 @@ module ApplicationHelper
     end
     params['send_after'] = time if time
     return params.to_json if test
-    #puts "Sending POST request to OneSignal with parameters: #{params}"
+    puts "Sending POST request to OneSignal with parameters: #{params}"
     uri = URI.parse('https://onesignal.com/api/v1/notifications')
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
@@ -87,7 +92,7 @@ module ApplicationHelper
     params = {'app_id' => ENV['ONESIGNAL_APP_ID'],
               'id' => onesignal_id}
     uri = URI.parse("https://onesignal.com/api/v1/notifications/#{params['id']}?app_id=#{params['app_id']}")
-    #puts "Sending DELETE request to OneSignal with parameters: #{params}"
+    puts "Sending DELETE request to OneSignal with parameters: #{params}"
     request = Net::HTTP::Delete.new(uri)
     request["Authorization"] = "Basic #{ENV['ONESIGNAL_KEY']}"
     req_options = {use_ssl: uri.scheme == "https"}
@@ -105,6 +110,7 @@ module ApplicationHelper
   def destroy_notification(notification_id)
     if notification_id
       # Destroy all notification with this OneSignal ID
+      puts "Cancelling Notification with OneSignal ID: #{notification_id}"
       Notification.where(notification_id: notification_id).destroy_all
       # Cancel the OneSignal scheduled notification
       cancel_notification(notification_id)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -108,12 +108,18 @@ module ApplicationHelper
   # Wrapper method that deletes notification on both OneSignal and the db.
   # @param [String] notification_id OneSignal Notification ID.
   def destroy_notification(notification_id)
-    if notification_id
+    if !notification_id.blank?
       # Destroy all notification with this OneSignal ID
-      puts "Cancelling Notification with OneSignal ID: #{notification_id}"
-      Notification.where(notification_id: notification_id).destroy_all
-      # Cancel the OneSignal scheduled notification
-      cancel_notification(notification_id)
+      begin
+        puts "Attempting to cancel Notification with OneSignal ID: #{notification_id}"
+        Notification.where(notification_id: notification_id).destroy_all
+        # Cancel the OneSignal scheduled notification
+        cancel_notification(notification_id)
+      rescue
+        puts "Failed cancelling Notification with OneSignal ID: #{notification_id}"
+      end
+    else
+      false
     end
   end
 end


### PR DESCRIPTION
## Description
Adds exception handling to notification cancellation. Improves notification message content. 

## Motivation and Context
1. The previous message told you that your shift comes up in X minutes, but doesn't tell you when the shift actually starts. To convey some more information, the start time of the shift is provided in the message now as well. 
2. Notification deletion is now done using exception handling, so shift deletion will not hang/freeze if the notification is not able to be deleted. 

## How Has This Been Tested?
1. Tested with full shift creation/deletion/update